### PR TITLE
bump for active link

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "author": "Consumer Financial Protection Bureau",
   "license": "CC0-1.0",
   "dependencies": {
-    "hmda-ui": "0.0.17",
+    "hmda-ui": "0.0.18",
     "prop-types": "15.6.0",
     "react": "16.3.2",
     "react-dom": "16.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3307,9 +3307,9 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hmda-ui@0.0.17:
-  version "0.0.17"
-  resolved "https://registry.yarnpkg.com/hmda-ui/-/hmda-ui-0.0.17.tgz#0a95277e2f9c59dca6c473f11c2e7adc52b1da47"
+hmda-ui@0.0.18:
+  version "0.0.18"
+  resolved "https://registry.yarnpkg.com/hmda-ui/-/hmda-ui-0.0.18.tgz#0f701b4382f2beabdd8f237f5f9d768c83075023"
   dependencies:
     babel-loader "8.0.0-beta.0"
     file-loader "1.1.11"


### PR DESCRIPTION
Update to go with https://github.com/cfpb/hmda-ui-modules/pull/5.