### PR TITLE
Include beta note and prevent non-beta sections from showing

### DIFF
--- a/src/Alert.css
+++ b/src/Alert.css
@@ -1,0 +1,100 @@
+.alert {
+  background-color: #f1f1f1;
+  background-position: 2rem 2rem;
+  background-repeat: no-repeat;
+  background-size: 5.2rem;
+  margin-top: 1.5em;
+  padding-bottom: 1.4rem;
+  padding-left: 3rem;
+  padding-right: 2rem;
+  padding-top: 2rem;
+  position: relative;
+}
+.alert::before {
+  background-color: #8b8b8b;
+  content: '';
+  height: 100%;
+  left: 0;
+  position: absolute;
+  top: 0;
+  width: 1rem;
+}
+.alert a {
+  color: #205493;
+}
+.alert a:focus,
+.alert a:hover {
+  color: #112e51;
+}
+.alert ul {
+  margin-bottom: 0;
+  margin-top: 1rem;
+  padding-left: 1rem;
+}
+
+.alert-slim {
+  background-position: 2rem 1rem;
+  padding-bottom: 1rem;
+  padding-top: 1rem;
+}
+.alert-slim .alert-text:only-child {
+  margin-bottom: 0.5rem;
+  padding-top: 0.5rem;
+}
+
+.alert-icon {
+  display: table-cell;
+  padding-right: 1rem;
+}
+
+.alert-body {
+  display: table-cell;
+  vertical-align: top;
+}
+
+.alert-heading {
+  margin-top: 0;
+  margin-bottom: 0;
+}
+
+.alert-text {
+  margin-bottom: 0;
+  margin-top: 0;
+}
+
+.alert-text:only-child {
+  margin-bottom: 1rem;
+  padding-top: 0.5rem;
+}
+
+.alert-success {
+  background-color: #e7f4e4;
+}
+.alert-success::before {
+  background-color: #2e8540;
+}
+
+.alert-warning {
+  background-color: #fff1d2;
+}
+.alert-warning::before {
+  background-color: #fdb81e;
+}
+
+.alert-error {
+  background-color: #f9dede;
+}
+.alert-error::before {
+  background-color: #e31c3d;
+}
+
+.alert-info {
+  background-color: #e1f3f8;
+}
+.alert-info::before {
+  background-color: #02bfe7;
+}
+
+.alert-paragraph {
+  width: 66ch;
+}

--- a/src/Alert.jsx
+++ b/src/Alert.jsx
@@ -1,0 +1,29 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+
+import './Alert.css'
+
+const Alert = ({ type = 'info', heading, children }) => {
+  if (!children) return null
+
+  return (
+    <div className={`alert alert-${type}`}>
+      <div className="alert-body">
+        {heading ? (
+          <h3 className="alert-heading">
+            {type === 'success' ? <span className="alert-check" /> : null}
+            {heading}
+          </h3>
+        ) : null}
+        {React.cloneElement(children, { className: 'alert-text' })}
+      </div>
+    </div>
+  )
+}
+
+Alert.propTypes = {
+  type: PropTypes.oneOf(['info', 'success', 'warning', 'error']),
+  heading: PropTypes.string
+}
+
+export default Alert

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,11 +6,20 @@ import Footer from './Footer'
 
 import './app.css'
 
+const betaLinks = [
+  { name: 'Home', href: '/' },
+  { name: 'Filing', href: '/filing/2019/' },
+  { name: 'Data Browser', href: '/data-browser/' }
+]
+
 const App = () => {
+  const isBeta = !!window.location.host.match('beta')
+  const headerLinks =  isBeta ? betaLinks : undefined
+
   return (
     <React.Fragment>
-      <Header />
-      <Home />
+      <Header links={headerLinks}/>
+      <Home isBeta={isBeta}/>
       <Footer />
     </React.Fragment>
   )

--- a/src/Beta.jsx
+++ b/src/Beta.jsx
@@ -1,0 +1,26 @@
+import React from 'react'
+import Alert from './Alert.jsx'
+
+const Beta = props => {
+  return (
+    <div className="Beta">
+      <Alert
+        heading={'HMDA Beta'}
+        type="warning"
+      >
+        <p>
+          Welcome to the portal for HMDA beta applications,
+          where you can test upcoming features and releases.
+          <br />
+          Data included is for testing purposes only.
+          <br />
+          To view the live version of all HMDA applications, 
+          {' '}<a href="https://ffiec.cfpb.gov">visit our homepage</a>.
+          {' '}For questions/suggestions, contact hmdahelp@cfpb.gov.
+        </p>
+      </Alert>
+    </div>
+  )
+}
+
+export default Beta

--- a/src/Header.jsx
+++ b/src/Header.jsx
@@ -4,17 +4,16 @@ import BannerUSA from './BannerUSA'
 import './Header.css'
 import logo from './images/ffiec-logo.svg'
 
-const links = [
+const defaultLinks = [
   { name: 'Home', href: '/' },
-  { name: 'Filing', href: '/filing/2018/' },
+  { name: 'Filing', href: '/filing/2019/' },
   { name: 'Data Browser', href: '/data-browser/' },
   { name: 'Data Publication', href: '/data-publication/' },
   { name: 'Tools', href: '/tools/' },
   { name: 'Documentation', href: '/documentation/' }
 ]
 
-const Header = props => {
-  const currentLinks = props.links || links
+const Header = ({links = defaultLinks}) => {
   return (
     <React.Fragment>
       <a className="skipnav" href="#main-content">
@@ -33,7 +32,7 @@ const Header = props => {
           </div>
           <nav className="nav">
             <ul className="nav-primary">
-              {currentLinks.map(link => {
+              {links.map(link => {
                 const path = window.location.pathname
                 let isActive = path.match(link.href)
                 if(link.href === '/') isActive = link.href === path

--- a/src/Home.jsx
+++ b/src/Home.jsx
@@ -1,10 +1,12 @@
 import React from 'react'
+import Beta from './Beta.jsx'
 import './Home.css'
 
-const Home = () => {
+const Home = ({isBeta}) => {
   return (
     <main className="home" id="main-content">
       <div className=" usa-grid-full">
+        {isBeta ? <Beta/> : null}
         <header className="usa-width-one-whole">
           <h1>The Home Mortgage Disclosure Act</h1>
           <p className="font-lead">
@@ -12,7 +14,6 @@ const Home = () => {
             publicly disclose information about mortgages.
           </p>
         </header>
-
         <div className="alert alert-info usa-width-one-whole">
           <div className="alert-body">
             <h3 className="alert-heading">Announcement</h3>
@@ -28,11 +29,11 @@ const Home = () => {
             <header>
               <h3>
                 <a
-                  href="/filing/2018/"
+                  href="/filing/2019/"
                   rel="noopener noreferrer"
                   target="_blank"
                 >
-                  Get started filing your HMDA data for 2018
+                  Get started filing your HMDA data for 2019
                 </a>
               </h3>
               <p>
@@ -42,6 +43,7 @@ const Home = () => {
                 accuracy and completeness of the data, and submit data for the
                 filing year.
               </p>
+              {isBeta ? null :
               <a
                 href="https://ffiec.cfpb.gov/filing/"
                 rel="noopener noreferrer"
@@ -49,6 +51,7 @@ const Home = () => {
               >
                 Access the 2017 HMDA Platform
               </a>
+              }
             </header>
 
             <header>
@@ -142,6 +145,7 @@ const Home = () => {
                 </a>.
               </li>
             </ul>
+            {isBeta ? null :
             <header>
               <h3>
                 <a href="/documentation/">Documentation</a>
@@ -150,6 +154,7 @@ const Home = () => {
                 A collection of documentation resources for HMDA data publication products.
               </p>
             </header>
+            }
           </div>
 
           <div className="card">
@@ -161,6 +166,7 @@ const Home = () => {
                  The HMDA Data Browser is a tool that allows users to filter and download HMDA datasets.
               </p>
             </header>
+           {isBeta ? null :
             <header>
               <h3>
                 <a href="/tools/">Tools</a>
@@ -186,7 +192,8 @@ const Home = () => {
                 </li>
               </ul>
             </header>
-
+            }
+            {isBeta ? null :
             <header>
               <h3>
                 <a href="/data-publication/">Data Publication</a>
@@ -226,6 +233,8 @@ const Home = () => {
                 </li>
               </ul>
             </header>
+           }
+           {isBeta ? null :
             <header>
               <h3>
                 <a href="https://www.consumerfinance.gov/data-research/hmda/">Research and Reports</a>
@@ -234,6 +243,7 @@ const Home = () => {
                 Research and reports on mortgage market activity
               </p>
             </header>
+           }
           </div>
         </div>
       </div>


### PR DESCRIPTION
Closes #93 
To test locally, add a `1||` before the `isBeta` test in `App.jsx`.

@chynnakeys The placeholder copy for the beta banner is in the screenshot below:
<img width="1173" alt="Screen Shot 2019-09-27 at 9 56 56 AM" src="https://user-images.githubusercontent.com/1558033/65787248-56499c80-e10d-11e9-9820-94e789a79c73.png">
